### PR TITLE
M*LIB: Enable release mode

### DIFF
--- a/mlib/Makefile
+++ b/mlib/Makefile
@@ -1,7 +1,7 @@
 all:run-test
 
 run-test:test.c ../common.c m-dict.h
-	$(CC) -O3 -Wall $< -o $@
+	$(CC) -O3 -Wall -DNDEBUG $< -o $@
 
 clean:
 	rm -fr run-test


### PR DESCRIPTION
Add NDEBUG to the command line to enable release mode for M*LIB