### PR TITLE
Update test.c to include a minimal hash function that returns 64 bits.

### DIFF
--- a/verstable/test.c
+++ b/verstable/test.c
@@ -1,9 +1,14 @@
 #include "../common.c"
 
+static inline uint64_t verstable_hash_fn(uint32_t key)
+{
+	return key * 0x9ddfea08eb382d69ull;
+}
+
 #define NAME intmap_t
 #define KEY_TY uint32_t
 #define VAL_TY uint32_t
-#define HASH_FN udb_hash_fn
+#define HASH_FN verstable_hash_fn
 #define CMPR_FN vt_cmpr_integer
 #include "verstable.h"
 


### PR DESCRIPTION
Verstable essentially requires a hash function that returns a 64-bit unsigned integer with entropy in the high, as well as low, bits. This is because the four highest bits of each key are stored and used during lookups to skip most failed key comparisons (each of which requires not only calling the comparison function but also accessing the buckets array, i.e. a likely cache miss). Without this mechanism, Verstable can still function relatively well, but it will incur a significant performance hit. The proposed hash function is the same mixer that ankerl::unordered_dense applies internally to guard against weak hash functions.